### PR TITLE
Add a link to Layout/EmptyLineAfterMagicComment

### DIFF
--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -5,13 +5,16 @@ module RuboCop
     module Style
       # This cop is designed to help you transition from mutable string literals
       # to frozen string literals.
-      # It will add the comment `# frozen_string_literal: true` to the top of
-      # files to enable frozen string literals. Frozen string literals may be
+      # It will add the `# frozen_string_literal: true` magic comment to the top
+      # of files to enable frozen string literals. Frozen string literals may be
       # default in future Ruby. The comment will be added below a shebang and
       # encoding comment.
       #
       # Note that the cop will ignore files where the comment exists but is set
       # to `false` instead of `true`.
+      #
+      # To require a blank line after this comment, please see
+      # `Layout/EmptyLineAfterMagicComment` cop.
       #
       # @example EnforcedStyle: always (default)
       #   # The `always` style will always add the frozen string literal comment


### PR DESCRIPTION
I didn't know that this was a "magic" comment, and that `Layout/EmptyLineAfterMagicComment` was the way to require a blank line after the `frozen_string_literal` comment.

I think it would be useful for the documentation to point people in the right direction.

Is there a special syntax like `@see` or something, for linking between these doc pages?

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). # N/A
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together. # N/A
* [x] Added tests.  # N/A
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.  # N/A

[1]: https://chris.beams.io/posts/git-commit/
